### PR TITLE
Support Laravel 11–13 (drop 10)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,15 +14,18 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,20 +18,20 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.4",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.9.2"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
-        "nunomaduro/collision": "^7.0|^8.0",
+        "nunomaduro/collision": "^8.0|^9.0",
         "larastan/larastan": "^2.0|^3.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "pestphp/pest": "^2.0|^3.0",
-        "pestphp/pest-plugin-laravel": "^2.0|^3.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^2.0|^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
         "phpstan/phpstan-phpunit": "^1.0|^2.0",
-        "phpunit/phpunit": "^10.0|^11.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,5 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
     ignoreErrors:
         - "#^Unsafe usage of new static#"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,16 +23,6 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>


### PR DESCRIPTION
## Summary
- Adopts Laravel 11+ baseline: drops Laravel 10 from `illuminate/contracts`, keeps 12, adds 13
- Bumps `orchestra/testbench`, `nunomaduro/collision`, `pestphp/pest`, `pestphp/pest-plugin-laravel`, and `phpunit/phpunit` constraints to cover the new generations
- CI matrix updated to Laravel 11/12/13 (L13 excluded on PHP 8.2 since L13 requires 8.3+)

## Test plan
- [ ] CI matrix passes for Laravel 11/12 across PHP 8.2/8.3/8.4
- [ ] CI matrix passes for Laravel 13 on PHP 8.3/8.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)